### PR TITLE
Fix accent-insensitive matches

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,10 +32,21 @@ const Chatbot = () => {
     setMessages(prev => [...prev, newMessage]);
   };
 
+  const normalizeText = (text) =>
+    text
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .trim();
+
   const findLocalResponse = (userInput) => {
-    const input = userInput.toLowerCase().trim();
-    const exactMatch = chatbotDataset.find(item => item.question.toLowerCase() === input);
-    const partialMatch = chatbotDataset.find(item => input.includes(item.question.toLowerCase()));
+    const input = normalizeText(userInput);
+    const exactMatch = chatbotDataset.find(
+      (item) => normalizeText(item.question) === input
+    );
+    const partialMatch = chatbotDataset.find((item) =>
+      input.includes(normalizeText(item.question))
+    );
     
     if (exactMatch) {
       return {


### PR DESCRIPTION
## Summary
- handle accents when matching user input to canned responses

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c10ce54808328bd9bac4f582db8ef